### PR TITLE
add: tests for pngimageparser. closes: #11

### DIFF
--- a/src/test/java/org/apache/commons/imaging/formats/png/PngImageParserTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngImageParserTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import org.apache.commons.imaging.ImageInfo;
+import org.apache.commons.imaging.ImagingException;
 import org.apache.commons.imaging.common.AllocationRequestException;
 import org.junit.jupiter.api.Test;
 
@@ -72,4 +73,53 @@ class PngImageParserTest extends AbstractPngTest {
         final ImageInfo imageInfo = new PngImageParser().getImageInfo(bytes, null);
         assertTrue(imageInfo.usesPalette());
     }
+
+    @Test
+    void testGetImageInfoNoChunks() {
+        final byte[] pngWithNoChunks = {
+            // PNG signature (8 bytes)
+            (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n',
+            0x00, 0x00, 0x00, 0x00,
+            // IEND chunk is always the last chunk of PNG file, The chunk's data field is empty.
+            'I', 'E', 'N', 'D',
+            0x00, 0x00, 0x00, 0x00
+        };
+
+        assertThrows(ImagingException.class, () -> new PngImageParser().getImageInfo(pngWithNoChunks, null));
+    }
+
+    @Test
+    void testGetImageInfoMoreThanOneHeader() {
+        final byte[] pngWithMoreThanOneHeader = {
+            // PNG signature (8 bytes)
+            (byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n',
+
+            // First IHDR chunk
+            0x00, 0x00, 0x00, 0x0D,
+            'I', 'H', 'D', 'R',
+            0x00, 0x00, 0x00, 0x01,  // width 
+            0x00, 0x00, 0x00, 0x01,  // height 
+            0x08,                     // bit depth
+            0x02,                     // color type 
+            0x00,                     // compression 
+            0x00,                     // filter 
+            0x00,                     // interlace
+            0x00, 0x00, 0x00, 0x00, // CRC
+
+            // Second IHDR chunk
+            0x00, 0x00, 0x00, 0x0D,
+            'I', 'H', 'D', 'R',
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x01,
+            0x08, 0x02, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+
+            // IEND chunk
+            0x00, 0x00, 0x00, 0x00,
+            'I', 'E', 'N', 'D',
+            0x00, 0x00, 0x00, 0x00  
+        };
+        assertThrows(ImagingException.class, () -> new PngImageParser().getImageInfo(pngWithMoreThanOneHeader, null));
+    }
+
 }


### PR DESCRIPTION
Added two unit tests to improve the branch coverage, which increased by 3% to 90%
- now reaches first branch, which tests if the chunk parameter is null
- now reaches second branch, which tests if multiple headers were given

closes: #11 
